### PR TITLE
R-3.x start server fix

### DIFF
--- a/modules/holodeckb2b-distribution/src/main/base/bin/startServer.bat
+++ b/modules/holodeckb2b-distribution/src/main/base/bin/startServer.bat
@@ -98,8 +98,7 @@ goto end
 :runAxis2
 rem set the classes by looping through the libs
 setlocal EnableDelayedExpansion
-set AXIS2_CLASS_PATH=%AXIS2_HOME%;%AXIS2_HOME%\conf;%JAVA_HOME%\lib\tools.jar;
-FOR %%c in ("%AXIS2_HOME%\lib\*.jar") DO set AXIS2_CLASS_PATH=!AXIS2_CLASS_PATH!;%%c
+set AXIS2_CLASS_PATH=%AXIS2_HOME%;%AXIS2_HOME%\conf;%JAVA_HOME%\lib\tools.jar;%AXIS2_HOME%\lib\*
 
 echo Using JAVA_HOME    %JAVA_HOME%
 echo Using AXIS2_HOME   %AXIS2_HOME%


### PR DESCRIPTION
Fixed the problem with starting HolodeckB2B instance in Windows OS if the classpath is too long.