### PR TITLE
Use 'exec' to start the java program.

### DIFF
--- a/modules/holodeckb2b-distribution/src/main/base/bin/startServer.sh
+++ b/modules/holodeckb2b-distribution/src/main/base/bin/startServer.sh
@@ -62,7 +62,7 @@ done
 
 cd "$AXIS2_HOME"
 
-java $JAVA_OPTS -classpath "$AXIS2_CLASSPATH" \
+exec java $JAVA_OPTS -classpath "$AXIS2_CLASSPATH" \
     -Djava.endorsed.dirs="$AXIS2_HOME/lib/endorsed":"$JAVA_HOME/jre/lib/endorsed":"$JAVA_HOME/lib/endorsed" \
     -Dderby.stream.error.file="$AXIS2_HOME/logs/derby.log" \
     org.apache.axis2.transport.SimpleAxis2Server \


### PR DESCRIPTION
Use 'exec' to start the java program, instead of forking the process, and keeping the shell script running it replaces the bash program with the java
program inside the process, and will start running that.

This is useful if you want to kill holodeck using, for example, supervisord,
now supervisord can kill the initially forked process (which first is a bash
script, then becomes the java program).