### PR TITLE
Changed the log4j to 2.17.2 because 2.17.0 vulnerabilities

### DIFF
--- a/modules/holodeckb2b-security/certmanager/pom.xml
+++ b/modules/holodeckb2b-security/certmanager/pom.xml
@@ -96,7 +96,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jaxb2-maven-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>2.4</version>
                 <executions>
                     <execution>
                         <id>xjc</id>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <axis2-version>1.7.7</axis2-version>
         <axiom-version>1.2.20</axiom-version>
         <netbeans.hint.license>gpl30</netbeans.hint.license>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.2</log4j.version>
     </properties>
 
     <modules>
@@ -99,6 +99,10 @@
         <module>modules/holodeckb2b-distribution</module>
         <module>modules/holodeckb2b-it</module>
         <module>modules/holodeckb2b-ui</module>
+        <!--
+        <module>modules/generic-utils</module>
+        <module>modules/file-backend</module>
+        -->
   </modules>
 
     <licenses>


### PR DESCRIPTION
Our security validation found vulnerabilities on log4j in 2.17.0 version.

Please, update it.