### PR TITLE
fix: Replace deprecated Integer constructor with Integer.valueOf()

### DIFF
--- a/modules/holodeckb2b-core/src/test/java/org/holodeckb2b/common/workerpool/XMLWorkerPoolCfgDocumentTest.java
+++ b/modules/holodeckb2b-core/src/test/java/org/holodeckb2b/common/workerpool/XMLWorkerPoolCfgDocumentTest.java
@@ -55,7 +55,7 @@ public class XMLWorkerPoolCfgDocumentTest {
 		}
 
         assertNotNull(result);
-        assertEquals(new Integer(5), result.getRefreshInterval());
+        assertEquals(Integer.valueOf(5), result.getRefreshInterval());
         
         final List<IWorkerConfiguration> workers = result.getWorkers();
         assertEquals(2, workers.size());

--- a/modules/holodeckb2b-ebms3as4/src/test/java/org/holodeckb2b/ebms3/packaging/PackagingTest.java
+++ b/modules/holodeckb2b-ebms3as4/src/test/java/org/holodeckb2b/ebms3/packaging/PackagingTest.java
@@ -169,8 +169,8 @@ public class PackagingTest {
 		}
 		
 		private void print(SAXParseException x) {
-			String msg = message.format(new Object[] { x.getSystemId(), new Integer(x.getLineNumber()),
-					new Integer(x.getColumnNumber()), x.getMessage() });
+			String msg = message.format(new Object[] { x.getSystemId(), Integer.valueOf(x.getLineNumber()),
+					Integer.valueOf(x.getColumnNumber()), x.getMessage() });
 			System.out.println(msg);
 		}
 


### PR DESCRIPTION
As a preparation for upgrading to Java 17:
- Replace new Integer(x) with Integer.valueOf(x) in XMLWorkerPoolCfgDocumentTest.java:58
- Replace new Integer(x) with Integer.valueOf(x) in PackagingTest.java:172-173 (2 occurrences)

Integer.valueOf() is the recommended approach as it:
- Avoids deprecation warning for the Integer(int) constructor
- Provides better performance through integer caching
- Follows Java best practices for boxing primitives

Fixes deprecation warnings:
  - Integer(int) in java.lang.Integer has been deprecated and marked for removal