### PR TITLE
refactor: Remove deprecated SecurityManager from PoolThreadFactory

### DIFF
--- a/modules/holodeckb2b-core/src/main/java/org/holodeckb2b/core/workerpool/PoolThreadFactory.java
+++ b/modules/holodeckb2b-core/src/main/java/org/holodeckb2b/core/workerpool/PoolThreadFactory.java
@@ -30,9 +30,7 @@ public class PoolThreadFactory implements ThreadFactory {
     private final String namePrefix;
 
     public PoolThreadFactory(String poolName) {
-        SecurityManager s = System.getSecurityManager();
-        group = (s != null) ? s.getThreadGroup() :
-                              Thread.currentThread().getThreadGroup();
+        group = Thread.currentThread().getThreadGroup();
         namePrefix = poolName + "-";
     }
 


### PR DESCRIPTION
As a preparation for upgrading to Java 17:
Remove deprecated SecurityManager usage that was used to obtain the ThreadGroup. Now directly uses Thread.currentThread().getThreadGroup() which is the recommended approach in modern Java and provides the same functionality.