### PR TITLE
Fix OCSP handling for revoked certificates and improve logging

### DIFF
--- a/modules/holodeckb2b-certmanager/src/main/java/org/holodeckb2b/security/trust/DefaultCertManager.java
+++ b/modules/holodeckb2b-certmanager/src/main/java/org/holodeckb2b/security/trust/DefaultCertManager.java
@@ -242,7 +242,7 @@ public class DefaultCertManager implements ICertificateManager {
 		} catch (Throwable bcUnavailable) {
 			log.fatal("Required BouncyCastle provider is not available! Details: {}", bcUnavailable.getMessage());
 			throw new SecurityProcessingException("BouncyCastle provider not available!");
-		}       
+		}
         // We enable OCSP by default, even if revocation checking is disabled
         Security.setProperty("ocsp.enable", "true");
 
@@ -564,8 +564,19 @@ public class DefaultCertManager implements ICertificateManager {
 				// If reason is "unspecified" or "undetermined" this could be caused by a problem in the OCSP check, so
 				// try again without
 				Reason reason = validationException.getReason();
+				log.warn("Certificate path validation failed - Reason: {}, Message: {}, Certificate: {}, Trace: {}",
+						 reason,
+						 validationException.getMessage(),
+						 validationException.getCertPath() != null && validationException.getIndex() >= 0 ?
+							 validationException.getCertPath().getCertificates().get(validationException.getIndex()) : "N/A",
+                         Utils.getExceptionTrace(validationException)
+                );
+
+				// Only fallback for OCSP infrastructure issues, NOT for actual revocation
 				if (performRevocationCheck
-					&& (reason == BasicReason.UNSPECIFIED || reason == BasicReason.UNDETERMINED_REVOCATION_STATUS)) {
+				    && (reason == BasicReason.UNSPECIFIED || reason == BasicReason.UNDETERMINED_REVOCATION_STATUS)
+				    && ! (validationException.getMessage() !== null && validationException.getMessage().toLowerCase().contains("certificate revoked"))
+                ) {
 					try {
 						log.debug("Validation with revocation check failed ({}), retry without",
 									validationException.getMessage());


### PR DESCRIPTION
Because I branched from the wrong branch and do not have permissions to change the target branch of my PR anymore, I have closed the original PR (#169) and created this new one.

This PR includes the changes from #169 and the requested PR optimizations. It now checks the reason message and does not retry when the message contains "certificate revoked" (case-insansitive). 