### PR TITLE
Restore workaround for redundant namespace declarations on SOAP headers

### DIFF
--- a/modules/holodeckb2b-ebms3as4/src/main/java/org/holodeckb2b/as4/multihop/ConfigureMultihop.java
+++ b/modules/holodeckb2b-ebms3as4/src/main/java/org/holodeckb2b/as4/multihop/ConfigureMultihop.java
@@ -18,6 +18,7 @@ package org.holodeckb2b.as4.multihop;
 
 import java.util.Collection;
 
+import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axiom.soap.SOAPHeaderBlock;
 import org.apache.axis2.addressing.AddressingConstants;
 import org.apache.axis2.addressing.EndpointReference;
@@ -83,8 +84,10 @@ public class ConfigureMultihop extends AbstractBaseHandler {
             else {
                 // This is a multi-hop message, set the multi-hop target on the eb:Messaging element
                 log.debug("Primary message is a multi-hop UserMessage -> set multi-hop target");
-                final SOAPHeaderBlock ebHeader = Messaging.getElement(procCtx.getParentContext().getEnvelope());
-                ebHeader.setRole(MultiHopConstants.NEXT_MSH_TARGET);
+                final SOAPEnvelope envelope = procCtx.getParentContext().getEnvelope();
+                final SOAPHeaderBlock ebHeader = Messaging.getElement(envelope);
+                final String roleAttr = envelope.getVersion().getRoleAttributeQName().getLocalPart();
+                ebHeader.addAttribute(roleAttr, MultiHopConstants.NEXT_MSH_TARGET, envelope.getNamespace());
             }
         } else if (primMU instanceof IPullRequest) {
             // If the primary message unit is a PullRequest the message is not sent using multi-hop as this is not

--- a/modules/holodeckb2b-ebms3as4/src/main/java/org/holodeckb2b/ebms3/packaging/Messaging.java
+++ b/modules/holodeckb2b-ebms3as4/src/main/java/org/holodeckb2b/ebms3/packaging/Messaging.java
@@ -18,6 +18,7 @@ package org.holodeckb2b.ebms3.packaging;
 
 import javax.xml.namespace.QName;
 
+import org.apache.axiom.soap.SOAPConstants;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axiom.soap.SOAPHeaderBlock;
 import org.holodeckb2b.interfaces.general.EbMSConstants;
@@ -52,8 +53,16 @@ public class Messaging {
             // No existing messaging element, so create a new one
             messaging = env.getHeader().addHeaderBlock(Q_ELEMENT_NAME.getLocalPart(), SOAPEnv.getEbms3Namespace(env));
 
-            // The messaging header must be understood by the MSH (see 5.2.1 core spec)
-            messaging.setMustUnderstand(true);
+            /*
+             * The mustUnderstand attribute is explicitly added here because setting
+             * the mustUnderstand flag on the object results in a redundant namespace
+             * declaration and prefix, e.g. xmlns:mustUnderstand="...."
+             * mustUnderstand:mustUnderstand="true"
+             * Although this isn't incorrect, this additional declaration can confuse
+             * other SOAP processors when performing c14n.
+             */
+            messaging.addAttribute(SOAPConstants.ATTR_MUSTUNDERSTAND,
+                                    SOAPConstants.ATTR_MUSTUNDERSTAND_TRUE, env.getNamespace());
         }
 
         return messaging;

--- a/modules/holodeckb2b-ebms3as4/src/test/java/org/holodeckb2b/ebms3/packaging/MessagingTest.java
+++ b/modules/holodeckb2b-ebms3as4/src/test/java/org/holodeckb2b/ebms3/packaging/MessagingTest.java
@@ -17,13 +17,17 @@
 package org.holodeckb2b.ebms3.packaging;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 
+import org.apache.axiom.soap.SOAPConstants;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axiom.soap.SOAPHeader;
 import org.apache.axiom.soap.SOAPHeaderBlock;
+import org.holodeckb2b.as4.multihop.MultiHopConstants;
 import org.holodeckb2b.interfaces.general.EbMSConstants;
 import org.junit.Test;
 
@@ -64,5 +68,40 @@ public class MessagingTest {
         assertEquals(soapHeaderBlock.getRole(), newSoapHeaderBlock.getRole());
         assertEquals(soapHeaderBlock.getVersion(),
                 newSoapHeaderBlock.getVersion());
+    }
+
+    @Test
+    public void testMustUnderstandSerializesCleanly() throws Exception {
+        SOAPEnvelope env = SOAPEnv.createEnvelope(SOAPEnv.SOAPVersion.SOAP_12);
+        Messaging.createElement(env);
+
+        assertNoRedundantNamespace(env, SOAPConstants.ATTR_MUSTUNDERSTAND);
+    }
+
+    @Test
+    public void testRoleAttributeSerializesCleanly() throws Exception {
+        SOAPEnvelope env = SOAPEnv.createEnvelope(SOAPEnv.SOAPVersion.SOAP_12);
+        SOAPHeaderBlock messaging = Messaging.createElement(env);
+
+        String roleAttr = env.getVersion().getRoleAttributeQName().getLocalPart();
+        messaging.addAttribute(roleAttr, MultiHopConstants.NEXT_MSH_TARGET, env.getNamespace());
+
+        assertNoRedundantNamespace(env, roleAttr);
+    }
+
+    private static String serializeToString(SOAPEnvelope env) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        env.serialize(baos);
+        return baos.toString("UTF-8");
+    }
+
+    private static void assertNoRedundantNamespace(SOAPEnvelope env, String attrName) throws Exception {
+        String xml = serializeToString(env);
+        assertFalse("Redundant namespace declaration 'xmlns:" + attrName + "=' breaks c14n"
+                    + " interoperability.\nActual XML:\n" + xml,
+                    xml.contains("xmlns:" + attrName + "="));
+        assertFalse("Wrongly-prefixed attribute '" + attrName + ":" + attrName + "=' breaks c14n"
+                    + " interoperability.\nActual XML:\n" + xml,
+                    xml.contains(attrName + ":" + attrName + "="));
     }
 }


### PR DESCRIPTION
Restores the workaround originally introduced in commit ada0200f (Nov 2020) that was lost during the project
  restructuring in the 6.0 development cycle (cabf0a2a). Adds regression tests to prevent the fix from being lost
  again.

  **Problem**

  Axiom's setMustUnderstand(true) and setRole() methods generate redundant namespace declarations on SOAP header
  attributes, producing output like:

  xmlns:mustUnderstand="http://www.w3.org/2003/06/soap-envelope"
  mustUnderstand:mustUnderstand="true"

  While technically valid XML, this confuses SOAP processors performing XML Canonicalization (c14n), causing
  interoperability failures with other AS4 implementations.

  **Fix**

  Replace setMustUnderstand(true) and setRole() with explicit addAttribute() calls using the envelope's namespace.
  This produces clean SOAP attributes without redundant namespace prefixes, while preserving identical SOAP
  semantics.

  **History**

  This exact fix was implemented by @sffieten in ada0200f with the message:
  "Work around to remove redundant namespace declarations on SOAP headers — Resolves issue with c14n by some other
  MSH"

  The fix was inadvertently lost when Messaging.java was moved during the project restructuring (cabf0a2a).

  **Test plan**

  - New regression tests verify serialized envelope has no redundant namespace declarations
  - Existing MessagingTest passes (verifies mustUnderstand semantics)
  - Full holodeckb2b-ebms3as4 module test suite passes