### PR TITLE
Fix trust anchor matching for cross-signed certificates

### DIFF
--- a/modules/holodeckb2b-certmanager/src/main/java/org/holodeckb2b/security/trust/DefaultCertManager.java
+++ b/modules/holodeckb2b-certmanager/src/main/java/org/holodeckb2b/security/trust/DefaultCertManager.java
@@ -513,12 +513,16 @@ public class DefaultCertManager implements ICertificateManager {
 
 		log.trace("Calculate cert path to validate (i.e. find first trust anchor)");
 		// We only validate the given certificate path up to the first certificate that is listed as a trust anchor,
-		// so remove any certificate from the given path that is already in the set of trust anchors
+		// so remove any certificate from the given path that is already in the set of trust anchors.
+		// Match by subject + public key instead of exact certificate equality, so that cross-signed
+		// certificates (same key, different issuer/signature) are recognized as trust anchors.
 		List<X509Certificate> cpToCheck = new ArrayList<>();
 		boolean foundAnchor = false;
 		for(int i = 0; !foundAnchor && i < certs.size(); i++) {
 			X509Certificate c = certs.get(i);
-			if (!(foundAnchor = trustAnchors.parallelStream().anyMatch(a -> a.getTrustedCert().equals(c))))
+			if (!(foundAnchor = trustAnchors.parallelStream().anyMatch(a ->
+					a.getTrustedCert().getSubjectX500Principal().equals(c.getSubjectX500Principal()) &&
+					a.getTrustedCert().getPublicKey().equals(c.getPublicKey()))))
 				cpToCheck.add(c);
 		}
 


### PR DESCRIPTION
When a TLS server includes a cross-signed root CA certificate in the chain (e.g. GTS Root R4 signed by GlobalSign), the current exact byte comparison via `.equals()` fails to match it against the self-signed version in the truststore. Both certificates represent the same CA with the same subject and public key, but have different issuers and signatures.

This causes "Trust anchor for certification path not found" errors for servers that include cross-signed root certificates in their TLS chain, which is common with Google Trust Services certificates.

The fix matches trust anchors by subject DN + public key instead of exact certificate equality, consistent with RFC 5280 trust anchor identification.