### PR TITLE
Handle missing CRL distribution points in revocation check fallback

### DIFF
--- a/modules/holodeckb2b-certmanager/src/main/java/org/holodeckb2b/security/trust/DefaultCertManager.java
+++ b/modules/holodeckb2b-certmanager/src/main/java/org/holodeckb2b/security/trust/DefaultCertManager.java
@@ -571,11 +571,15 @@ public class DefaultCertManager implements ICertificateManager {
 						Utils.getExceptionTrace(validationException));
 
 				// If reason is "unspecified" or "undetermined" this could indicate either that the certificate is not
-				// valid, or that there was a problem in executing the OCSP check. In the latter case, try again without
+				// valid, or that there was a problem in executing the revocation check. In the latter case, try again
+				// without. This covers OCSP infrastructure issues (IOException cause) and missing CRL distribution
+				// points (RecoverableCertPathValidatorException with "No CRLs found" message).
 				if (performRevocationCheck
 					&& (reason == BasicReason.UNDETERMINED_REVOCATION_STATUS
 					|| (reason == BasicReason.UNSPECIFIED && validationException.getCause() != null
-							&& (validationException.getCause() instanceof IOException)))) {
+							&& (validationException.getCause() instanceof IOException))
+					|| (reason == BasicReason.UNSPECIFIED && validationException.getMessage() != null
+							&& validationException.getMessage().contains("No CRLs found")))) {
 					try {
 						log.debug("Validation with revocation check failed ({}), retry without",
 								validationException.getMessage());


### PR DESCRIPTION
When BouncyCastle PKIX validates a certificate chain with revocation checking enabled, it fails with UNSPECIFIED reason and "No CRLs found for issuer" if the issuing CA does not provide CRL distribution points. This is common for intermediates signed by root CAs (e.g. Google Trust Services WE1 signed by GTS Root R4).

The existing fallback only retried without revocation for UNDETERMINED_REVOCATION_STATUS or UNSPECIFIED with an IOException cause. The "No CRLs found" error uses a RecoverableCertPathValidatorException (not IOException), so the fallback was not triggered.

This adds a message-based check for "No CRLs found" to also retry without revocation checking in this case.