### PR TITLE
Index the two lookup columns on MSG_UNIT, and select the latest processing state with NOT EXISTS

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -23,6 +23,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * `shutdown()` method to `IMessageProcessingEventHandlerFactory` to release any held resources
 * Functional tests for security and trust components (thanks to @ckaaber)
 * Detailed logging of unexpected exceptions when processing messages
+* Indexes on the `MESSAGE_ID` and `CORE_ID` columns of the `MSG_UNIT` table of the default _Metadata Storage Provider_.
+  These are the columns message units are looked up by, so every lookup previously required a full table scan
 
 ### Changed
 * Configuration of revocation checks which can be specified to be _mandatory_, _optional_ or _never_. Default is now
@@ -37,6 +39,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Moved `getFromMessageContext()` from `org.holodeckb2b.core.MessageProcessingContext` to 
   `org.holodeckb2b.interfaces.core.IMessageProcessingContext`
 * Moved `TLSCertificateTrustManager` from `org.holodeckb2b.core.axis2` to `org.holodeckb2b.interfaces.security.trust` package
+* The default _Metadata Storage Provider_ now selects the current processing state of a message unit with a `NOT EXISTS`
+  anti-join instead of a correlated `MAX` sub-query. This mainly benefits `getMessageUnitsWithLastStateChangedBefore()`,
+  used by the _PurgeOldMessagesWorker_, where indexes cannot help
 
 ### Fixed
 * HTTP 500 instead of 400 returned when request contains invalid MIME multi-part Content-Type header

--- a/modules/holodeckb2b-default-mds/src/main/java/org/holodeckb2b/storage/metadata/DefaultMetadataStorageProvider.java
+++ b/modules/holodeckb2b-default-mds/src/main/java/org/holodeckb2b/storage/metadata/DefaultMetadataStorageProvider.java
@@ -268,7 +268,7 @@ public class DefaultMetadataStorageProvider implements IMetadataStorageProvider 
 						                + "FROM " + JPAObjectHelper.getJPAClass(type).getSimpleName() + " mu "
 						                + "JOIN mu.states s1 "
 						                + "WHERE mu.PMODE_ID IN :pmodeIds "
-						                + "AND s1.PROC_STATE_NUM = (SELECT MAX(s2.PROC_STATE_NUM) FROM mu.states s2) "
+						                + "AND NOT EXISTS (SELECT 1 FROM mu.states s2 WHERE s2.PROC_STATE_NUM > s1.PROC_STATE_NUM) "
 						                + "AND s1.STATE = :state "
 						                + "ORDER BY s1.START", JPAObjectHelper.getJPAClass(type))
 								      .setParameter("pmodeIds", pmodeIds)
@@ -284,7 +284,7 @@ public class DefaultMetadataStorageProvider implements IMetadataStorageProvider 
 				                + "FROM " + JPAObjectHelper.getJPAClass(type).getSimpleName() + " mu "
 		                		+ "JOIN mu.states s1 "
 				                + "WHERE mu.DIRECTION = :direction "
-				                + "AND s1.PROC_STATE_NUM = (SELECT MAX(s2.PROC_STATE_NUM) FROM mu.states s2) "
+				                + "AND NOT EXISTS (SELECT 1 FROM mu.states s2 WHERE s2.PROC_STATE_NUM > s1.PROC_STATE_NUM) "
 				                + "AND s1.STATE IN :states "
 				                + "ORDER BY mu.MU_TIMESTAMP", JPAObjectHelper.getJPAClass(type))
                                 .setParameter("direction", direction)
@@ -320,7 +320,7 @@ public class DefaultMetadataStorageProvider implements IMetadataStorageProvider 
 								"SELECT mu "
 				                + "FROM MessageUnit mu "
 				                + "JOIN mu.states s1 "
-				                + "WHERE s1.PROC_STATE_NUM = (SELECT MAX(s2.PROC_STATE_NUM) FROM mu.states s2) "
+				                + "WHERE NOT EXISTS (SELECT 1 FROM mu.states s2 WHERE s2.PROC_STATE_NUM > s1.PROC_STATE_NUM) "
 				                + "AND   s1.START <= :beforeDate", MessageUnit.class)
 								.setParameter("beforeDate", maxLastChangeDate, TemporalType.TIMESTAMP));
 	}
@@ -393,7 +393,7 @@ public class DefaultMetadataStorageProvider implements IMetadataStorageProvider 
                            + "JOIN um.states s1 "
                            + "WHERE um.DIRECTION = org.holodeckb2b.interfaces.messagemodel.Direction.IN "
                            + "AND um.MESSAGE_ID = :msgId "
-                           + "AND s1.PROC_STATE_NUM = (SELECT MAX(s2.PROC_STATE_NUM) FROM um.states s2) "
+                           + "AND NOT EXISTS (SELECT 1 FROM um.states s2 WHERE s2.PROC_STATE_NUM > s1.PROC_STATE_NUM) "
                            + "AND s1.STATE IN ( org.holodeckb2b.interfaces.processingmodel.ProcessingState.DELIVERED, "
                            + 			"org.holodeckb2b.interfaces.processingmodel.ProcessingState.OUT_FOR_DELIVERY, "
         				   + 			"org.holodeckb2b.interfaces.processingmodel.ProcessingState.FAILURE)";
@@ -449,7 +449,7 @@ public class DefaultMetadataStorageProvider implements IMetadataStorageProvider 
 						"SELECT mu "
 		                + "FROM MessageUnit mu "
 		                + "JOIN mu.states s1 "
-		                + "WHERE s1.PROC_STATE_NUM = (SELECT MAX(s2.PROC_STATE_NUM) FROM mu.states s2) "
+		                + "WHERE NOT EXISTS (SELECT 1 FROM mu.states s2 WHERE s2.PROC_STATE_NUM > s1.PROC_STATE_NUM) "
 		                + "AND   s1.START <= :beforeDate "
 		                + "ORDER BY s1.START DESC", MessageUnit.class)
 						.setParameter("beforeDate", upto, TemporalType.TIMESTAMP)

--- a/modules/holodeckb2b-default-mds/src/main/java/org/holodeckb2b/storage/metadata/jpa/MessageUnit.java
+++ b/modules/holodeckb2b-default-mds/src/main/java/org/holodeckb2b/storage/metadata/jpa/MessageUnit.java
@@ -27,6 +27,7 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
@@ -53,7 +54,17 @@ import org.holodeckb2b.interfaces.storage.IMessageUnitEntity;
  * @since  3.0.0
  */
 @Entity
-@Table(name = "MSG_UNIT")
+@Table(name = "MSG_UNIT", indexes = {
+		/*
+		 * MESSAGE_ID and CORE_ID are the two columns the provider looks message units up by, but
+		 * neither is indexed, so every lookup is a full scan of MSG_UNIT. They are used by
+		 * getMessageUnitsWithId(), getMessageUnitWithCoreId(), isAlreadyProcessed(),
+		 * getNumberOfTransmissions() and the duplicate check in storeMessageUnit(), i.e. on the
+		 * path of every single message that is processed.
+		 */
+		@Index(name = "IDX_MSG_UNIT_MESSAGE_ID", columnList = "MESSAGE_ID"),
+		@Index(name = "IDX_MSG_UNIT_CORE_ID", columnList = "CORE_ID")
+})
 @Inheritance(strategy = InheritanceType.JOINED)
 public abstract class MessageUnit implements JPAEntityObject {
 	private static final long serialVersionUID = 7831718632775664604L;


### PR DESCRIPTION
The default metadata storage provider declares no secondary indexes, and five queries
identify a message unit's current processing state with a correlated `MAX` subquery. Both
cost more than they need to.

The two commits are independent and can be taken separately — the first is a missing index
declaration, the second a query rewrite. Happy to split them into two PRs if you would
rather discuss the second on its own.

## 1. Index `MESSAGE_ID` and `CORE_ID` on `MSG_UNIT`

These are the two columns the provider looks message units up by, and neither is indexed,
so every lookup scans `MSG_UNIT` in full. Both are on the processing path of every message:
`getMessageUnitsWithId()`, `getMessageUnitWithCoreId()`, `isAlreadyProcessed()`,
`getNumberOfTransmissions()`, and the duplicate check in `storeMessageUnit()`.

| | before | after |
|---|---|---|
| `MESSAGE_ID` lookup | 30.10 ms | **0.073 ms** |
| `CORE_ID` lookup | 29.86 ms | **0.040 ms** |
| `isAlreadyProcessed` | 30.27 ms | **0.074 ms** |

## 2. Select the latest processing state with `NOT EXISTS`

Five queries use

```
AND s1.PROC_STATE_NUM = (SELECT MAX(s2.PROC_STATE_NUM) FROM mu.states s2)
```

replaced by

```
AND NOT EXISTS (SELECT 1 FROM mu.states s2 WHERE s2.PROC_STATE_NUM > s1.PROC_STATE_NUM)
```

Semantically equivalent, but the anti-join form lets the optimiser start from the rows that
match the state filter instead of computing a maximum for every candidate message unit.

| | before | after |
|---|---|---|
| `getMessageUnitsInState` | 487 ms | 465 ms |
| &nbsp;&nbsp;with the indexes from commit 1 | 445 ms | **373 ms** |
| `getMessageUnitsWithLastStateChangedBefore` | 4,205 ms | 3,539 ms |
| &nbsp;&nbsp;with the same indexes | 4,401 ms | **2,887 ms** |

The second one is the query `PurgeOldMessagesWorker` runs. It takes over four seconds at
this size, and **no index affects it** — only the query shape does. That is the main reason
I think this one is worth taking: it is the query where indexing has nothing left to give.

Derby compiles the correlated form into a hash exists join, so the gain is smaller than the
shape change might suggest — but it is consistently in the same direction, and never slower.

## Verification

- All 58 existing tests in `holodeckb2b-default-mds` pass unchanged, including the ten
  `QueryTests` that assert the latest-state semantics of the affected methods
  (`testGetMessageUnitsInState`, `testGetMessageUnitsWithLastStateChangedBefore`,
  `testGetMessageUnitsForPModesInState`, `testIsAlreadyProcessed`).
- Schema generation from the module's own test persistence unit confirms Hibernate emits
  `create index IDX_MSG_UNIT_MESSAGE_ID on MSG_UNIT (MESSAGE_ID);` and the `CORE_ID`
  equivalent.
- The change log is updated under 9.0.0.

## How the measurements were taken

Embedded Derby 10.12.1.1, the version the distribution bundles. 200,000 `MSG_UNIT`
(100,000 of them `USER_MESSAGE`), 800,000 `MSG_STATE` with four states each, plus payloads
and message properties in proportion. `SYSCS_UTIL.SYSCS_UPDATE_STATISTICS` run before each
measurement; best of five, prepared statements, result sets fully consumed.

One caveat on the purge figures: the cutoff date matched every message unit in the set, so
the absolute numbers are a worst case. The ratio between the two forms holds.

## Branch note

Submitted against `next` as the contribution guidelines ask. One note on how the tests were
run, since I could not build the `next` reactor itself: it needs
`org.holodeckb2b.commons:generic-utils:3.0.0` and `org.holodeckb2b.axis2:axis2-binary:1.0.0`,
neither of which is on Maven Central — and the `generic-utils` repository is at `2.1.0` on both
its branches. They appear to be unreleased, so the branch is not currently buildable from a
clean checkout.

That turns out not to matter for this module. `modules/holodeckb2b-default-mds/src` is
**byte-identical between `next` and `v8.1.0`** (tree `9b81af66` on both — the 8.1.1 truncation
change went to `master` only), and with these two commits applied both become tree `f4bf41df`.
So building the module on the `v8.1.0` base compiles and exercises exactly the source this PR
puts on `next`, and there **all 58 tests pass**.

For completeness I also ran them on current `master` (`4c8ac390`, 8.1.1), where the truncation
change is present: 58/58 there too. Those commits are on the
`perf/mds-missing-indexes-and-latest-state-rewrite` branch of my fork if you would rather take
them against `master`.

Found while working on the Danish EESSI implementation, which runs Holodeck B2B with a
message history considerably larger than the test fixtures.
